### PR TITLE
Add pipeline to performance test runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+variables.yaml
+.idea

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This will configure the target `census-eq` to point to the eq team on Concourse.
 #### Prerequisites
 You must have a project with a *Google Container Registry (GCR)* already set up to be able to push built images.
 Set your registry in *variables.yaml* to `eu.gcr.io/<gcp_project_id>`. The `gcp_project_id` should be the ID of the GCP project under which the container registry is hosted.
+Ensure in the GCR settings, the visibility is set to Public.
 
 #### Scheduled pipeline triggers
 The first time you create a pipeline that depend on a time resource, you *will not* be able to trigger tasks that depend on these time resources because there will be no available versions of time resource. In our case, a version of this resource is only created at the time specified by the pipeline, for example, the benchmark-timed-schedule pipeline is initiated at 3 AM.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,85 @@
 # eq-concourse-peformance-testing
+
+This repo holds the pipeline to performance test eQ Survey Runner.
+
+## Authenticate with Concourse
+
+Log in to concourse with:
+
+```
+fly -t census-eq login -c <concourse_url>
+```
+
+This will configure the target `census-eq` to point to the eq team on Concourse.
+
+## Development Environments
+
+#### Prerequisites
+You must have a project with a *Google Container Registry (GCR)* already set up to be able to push built images.
+Set your registry in *variables.yaml* to `eu.gcr.io/<gcp_project_id>`. The `gcp_project_id` should be the ID of the GCP project under which the container registry is hosted.
+
+#### Scheduled pipeline triggers
+The first time you create a pipeline that depend on a time resource, you *will not* be able to trigger tasks that depend on these time resources because there will be no available versions of time resource. In our case, a version of this resource is only created at the time specified by the pipeline, for example, the benchmark-timed-schedule pipeline is initiated at 3 AM.
+Therefore, for development purposes, you will need to set the source start time to a short while in the future so that you have enough time to create and unpause the pipeline. This only needs to be done once to kick start the initial build, after which this can be reset to default.
+
+**Resource for benchmark-timed-schedule.yaml**
+```yaml
+- name: scheduled-benchmark-trigger
+    type: time
+    source:
+      start: 03:00 AM
+      stop: 04:00 AM
+      location: Europe/London
+```
+
+#### Pipelines
+
+Pipeline | Schedule | Notes |
+--- | --- | --- |
+benchmark-timed-schedule.yaml | 3 AM every day | Deploys infrastructure required to carries out a performance test using eq-survey-runner-benchmark for which the outputs are stored in a GCS bucket. Once complete the infrastructure is torn down ready for the next scheduled test.
+
+#### Deployment process
+
+To ***create*** a pipeline to deploy your own environments (in order to test pipelines etc.) you can do so as follows:
+
+1. Fill in any missing variables specified in *variables.yaml* *(copied from variables.yaml.example)*. Ask a team member for help with the values.
+1. Upload your pipeline to Concourse using a command like:
+
+    ```
+    fly -t census-eq set-pipeline -p <PIPELINE_NAME> -c <PIPELINE_CONFIG_FILE> --load-vars-from variables.yaml
+    ```
+   *For example*
+    ```bash
+    fly -t census-eq set-pipeline -p my-benchmark-pipeline -c benchmark-timed-schedule.yaml --load-vars-from variables.yaml
+    ```
+    This will create a pipeline called *my-benchmark-pipeline*. This will also load a few templating variables from *variables.yaml*. There is a specification for this in the repo.
+1. Navigate to the Concourse UI and unpause your pipeline to trigger the builds. Alternatively you can run:
+    ```
+    fly -t census-eq unpause-pipeline -p <PIPELINE_NAME>
+    ```
+
+---
+
+To ***destroy*** your pipeline, you can run the following command:
+```
+fly -t census-eq destroy-pipeline -p <PIPELINE_NAME>
+```
+
+---
+
+## Secrets
+
+Secrets are currently hooked into Kubernetes secrets, which are available on the cluster. To get a full list of secrets available for use within the pipeline, you can log in to the cluster and get the secrets.
+
+Log in to the cluster using:
+```
+gcloud container clusters get-credentials k8s-cd --region <region> --project <gcp_project_id>
+```
+Get the [Kubernetees secrets](https://kubernetes.io/docs/concepts/configuration/secret/) using:
+```bash
+kubectl --namespace=concourse-main get secrets
+```
+
+## Slack
+
+Pipeline deployment notifications are alerted to the slack channel defined by `slack_channel_name` in *variables.yaml*. *(Do not include the `#`).*

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will configure the target `census-eq` to point to the eq team on Concourse.
 #### Prerequisites
 You must have a project with a *Google Container Registry (GCR)* already set up to be able to push built images.
 Set your registry in *variables.yaml* to `eu.gcr.io/<gcp_project_id>`. The `gcp_project_id` should be the ID of the GCP project under which the container registry is hosted.
-Ensure in the GCR settings, the visibility is set to Public.
+Ensure in the GCR settings, the visibility is set to Public. To do this, you must first initialize a registry manually via the UI or run the docker build step which would fail the first time since it would be private.
 
 #### Scheduled pipeline triggers
 The first time you create a pipeline that depend on a time resource, you *will not* be able to trigger tasks that depend on these time resources because there will be no available versions of time resource. In our case, a version of this resource is only created at the time specified by the pipeline, for example, the benchmark-timed-schedule pipeline is initiated at 3 AM.

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -62,7 +62,7 @@ resources:
   - name: scheduled-benchmark-trigger
     type: time
     source:
-      start: 03:00 AM
+      start: 03:34 PM
       stop: 04:00 AM
       location: Europe/London
 
@@ -176,6 +176,7 @@ jobs:
             repository: theorf/google-cloud-sdk-helm
         params:
           SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+          IMPORT_EXISTING_PROJECT: ((import_existing_project))
         inputs:
           - name: eq-survey-runner-benchmark
         run:
@@ -196,7 +197,9 @@ jobs:
               helm init --client-only
               helm plugin install https://github.com/rimusz/helm-tiller
 
-              PROJECT_ID=($(gcloud projects list --filter=name="((project_name))" --format="value(PROJECT_ID)"))
+              FILTER_BY=$(if [[ "$IMPORT_EXISTING_PROJECT" = true ]]; then echo "project_id"; else echo "name"; fi)
+
+              PROJECT_ID=($(gcloud projects list --filter=${FILTER_BY}="((project_name))" --format="value(PROJECT_ID)"))
 
               [[ "${#PROJECT_ID[@]}" = 1 ]] || exit 1
 

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -1,3 +1,19 @@
+##############################################################################
+# YAML Anchors
+##############################################################################
+common_infrastructure_params: &common_infrastructure_params
+  TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
+  TF_VAR_gcp_folder_id: ((gcp_folder_id))
+  TF_VAR_gcp_billing_account: ((gcp_billing_account))
+  TF_VAR_project_env: ((gcp_project_label))
+  PROJECT_NAME: ((project_name))
+  SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+  GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
+
+##############################################################################
+# Resources
+##############################################################################
+
 resource_types:
   - name: slack-notification
     type: docker-image
@@ -96,14 +112,8 @@ jobs:
           source:
             repository: google/cloud-sdk
         params:
-          TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
-          TF_VAR_gcp_folder_id: ((gcp_folder_id))
-          TF_VAR_gcp_billing_account: ((gcp_billing_account))
-          TF_VAR_project_env: ((gcp_project_label))
-          PROJECT_NAME: ((project_name))
+          <<: *common_infrastructure_params
           IMPORT_EXISTING_PROJECT: ((import_existing_project))
-          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-          GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
         inputs:
           - name: eq-terraform-load-generator
         run:
@@ -256,13 +266,7 @@ jobs:
           source:
             repository: google/cloud-sdk
         params:
-          TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
-          TF_VAR_gcp_folder_id: ((gcp_folder_id))
-          TF_VAR_gcp_billing_account: ((gcp_billing_account))
-          TF_VAR_project_env: ((gcp_project_label))
-          PROJECT_NAME: ((project_name))
-          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
-          GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
+          <<: *common_infrastructure_params
         inputs:
           - name: eq-terraform-load-generator
         run:

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -99,12 +99,12 @@ jobs:
 ##############################################################################
 
   - name: deploy-infrastructure
-    serial_groups: [deploy-survey-runner-benchmark]
+    serial_groups: [run-benchmark]
     plan:
     - get: eq-terraform-load-generator
     - get: scheduled-benchmark-trigger
       trigger: true
-    - task: Build & Deploy Load Generator
+    - task: Build & Deploy Infrastructure
       config:
         platform: linux
         image_resource:
@@ -142,7 +142,7 @@ jobs:
       params:
         channel: '#((slack_channel_name))'
         attachments:
-          - pretext: Load Generator Deploy Failed
+          - pretext: Load Generator Infrastructure Deploy Failed
             color: danger
             title: Concourse Build $BUILD_ID
             title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
@@ -151,23 +151,23 @@ jobs:
       params:
         channel: '#((slack_channel_name))'
         attachments:
-          - pretext: Load Generator Deploy Passed
+          - pretext: Load Generator Infrastructure Deploy Passed
             color: good
             title: Concourse Build $BUILD_ID
             title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
 
 ##############################################################################
-# Deploy Survey Runner Benchmark
+# Run Benchmark
 ##############################################################################
 
-  - name: deploy-survey-runner-benchmark
-    serial_groups: [deploy-survey-runner-benchmark]
+  - name: run-benchmark
+    serial_groups: [run-benchmark]
     plan:
     - get: eq-survey-runner-benchmark
     - get: scheduled-benchmark-trigger
       passed: [build-survey-runner-benchmark, deploy-infrastructure]
       trigger: true
-    - task: Deploy Survey Benchmark
+    - task: Run Survey Runner Benchmark
       config:
         platform: linux
         image_resource:
@@ -230,7 +230,7 @@ jobs:
         params:
           channel: '#((slack_channel_name))'
           attachments:
-            - pretext: Survey Benchmark Deploy Failed
+            - pretext: Survey Runner Benchmark Failed
               color: danger
               title: Concourse Build $BUILD_ID
               title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
@@ -239,7 +239,7 @@ jobs:
         params:
           channel: '#((slack_channel_name))'
           attachments:
-            - pretext: Survey Benchmark Deploy Passed
+            - pretext: Survey Runner Benchmark Passed
               color: good
               title: Concourse Build $BUILD_ID
               title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
@@ -250,15 +250,15 @@ jobs:
 ##############################################################################
 
   - name: destroy-infrastructure
-    serial_groups: [deploy-survey-runner-benchmark]
+    serial_groups: [run-benchmark]
     plan:
     - get: eq-terraform-load-generator
     - get: eq-survey-runner-benchmark
-      passed: [build-survey-runner-benchmark, deploy-survey-runner-benchmark]
+      passed: [build-survey-runner-benchmark, run-benchmark]
     - get: scheduled-benchmark-trigger
-      passed: [build-survey-runner-benchmark, deploy-survey-runner-benchmark]
+      passed: [build-survey-runner-benchmark, run-benchmark]
       trigger: true
-    - task: Destroy Load Generator
+    - task: Destroy Infrastructure
       config:
         platform: linux
         image_resource:
@@ -308,7 +308,7 @@ jobs:
       params:
         channel: '#((slack_channel_name))'
         attachments:
-          - pretext: Load Generator Destroy Failed
+          - pretext: Load Generator Infrastructure Deploy Failed
             color: danger
             title: Concourse Build $BUILD_ID
             title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
@@ -317,7 +317,7 @@ jobs:
       params:
         channel: '#((slack_channel_name))'
         attachments:
-          - pretext: Load Generator Destroy Passed
+          - pretext: Load Generator Infrastructure Deploy Passed
             color: good
             title: Concourse Build $BUILD_ID
             title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -56,7 +56,7 @@ jobs:
 # eQ Survey Benchmark
 ##############################################################################
 
-  - name: build-eq-survey-runner-benchmark
+  - name: build-survey-runner-benchmark
     plan:
     - get: eq-survey-runner-benchmark
     - get: scheduled-benchmark-trigger
@@ -82,7 +82,7 @@ jobs:
 # Deploy Cluster
 ##############################################################################
 
-  - name: deploy-load-generator
+  - name: deploy-infrastructure
     serial_groups: [deploy-survey-runner-benchmark]
     plan:
     - get: eq-terraform-load-generator
@@ -99,6 +99,7 @@ jobs:
           TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
           TF_VAR_gcp_folder_id: ((gcp_folder_id))
           TF_VAR_gcp_billing_account: ((gcp_billing_account))
+          PROJECT_NAME: ((project_name))
           IMPORT_EXISTING_PROJECT: ((import_existing_project))
           SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
           GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
@@ -124,7 +125,7 @@ jobs:
 
               tfenv install
 
-              ./scripts/deploy_infrastructure.sh ((project_name))
+              ./scripts/deploy_infrastructure.sh
     on_failure:
       put: slack-alert
       params:
@@ -153,7 +154,7 @@ jobs:
     plan:
     - get: eq-survey-runner-benchmark
     - get: scheduled-benchmark-trigger
-      passed: [build-eq-survey-runner-benchmark, deploy-load-generator]
+      passed: [build-survey-runner-benchmark, deploy-infrastructure]
       trigger: true
     - task: Deploy Survey Benchmark
       config:
@@ -201,8 +202,8 @@ jobs:
                 --set locustOptions="((locust_options))" \
                 --set host=https://((runner_fully_qualified_domain_name)) \
                 --set container.image=((docker_registry))/eq-survey-runner-benchmark:${COMMIT_HASH} \
-                --set gcsOutputBucket=${GCS_OUTPUT_BUCKET} \
-                --set outputDirectory="timed-schedule"
+                --set output.bucket=${GCS_OUTPUT_BUCKET} \
+                --set output.directory="timed-schedule"
 
               JOB_NAME=$(kubectl get jobs '--output=jsonpath={.items[*].metadata.name}')
 
@@ -231,14 +232,14 @@ jobs:
 # Destroy Cluster
 ##############################################################################
 
-  - name: destroy-load-generator
+  - name: destroy-infrastructure
     serial_groups: [deploy-survey-runner-benchmark]
     plan:
     - get: eq-terraform-load-generator
     - get: eq-survey-runner-benchmark
-      passed: [build-eq-survey-runner-benchmark, deploy-survey-runner-benchmark]
+      passed: [build-survey-runner-benchmark, deploy-survey-runner-benchmark]
     - get: scheduled-benchmark-trigger
-      passed: [build-eq-survey-runner-benchmark, deploy-survey-runner-benchmark]
+      passed: [build-survey-runner-benchmark, deploy-survey-runner-benchmark]
       trigger: true
     - task: Destroy Load Generator
       config:
@@ -251,6 +252,7 @@ jobs:
           TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
           TF_VAR_gcp_folder_id: ((gcp_folder_id))
           TF_VAR_gcp_billing_account: ((gcp_billing_account))
+          PROJECT_NAME: ((project_name))
           SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
           GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
         inputs:

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -99,6 +99,7 @@ jobs:
           TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
           TF_VAR_gcp_folder_id: ((gcp_folder_id))
           TF_VAR_gcp_billing_account: ((gcp_billing_account))
+          TF_VAR_project_env: ((gcp_project_label))
           PROJECT_NAME: ((project_name))
           IMPORT_EXISTING_PROJECT: ((import_existing_project))
           SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
@@ -193,6 +194,7 @@ jobs:
               COMMIT_HASH=$(cat .git/HEAD | xargs echo -n)
 
               gcloud container clusters get-credentials runner-benchmark --region ((region)) --project ${PROJECT_ID}
+              runtime_date_string="$(date +'%Y-%m-%dT%H:%M:%S')"
 
               helm tiller run \
                 helm upgrade --install \
@@ -202,8 +204,13 @@ jobs:
                 --set locustOptions="((locust_options))" \
                 --set host=https://((runner_fully_qualified_domain_name)) \
                 --set container.image=((docker_registry))/eq-survey-runner-benchmark:${COMMIT_HASH} \
+                --set userWaitTimeMinSeconds=((user_wait_time_min_seconds)) \
+                --set userWaitTimemaxSeconds=((user_wait_time_max_seconds)) \
+                --set cpu=((requested_cpu_per_pod)) \
+                --set memory=((requested_memory_per_pod)) \
+                --set parallelism=((parallelism)) \
                 --set output.bucket=${GCS_OUTPUT_BUCKET} \
-                --set output.directory="timed-schedule"
+                --set output.directory="timed-schedule/${runtime_date_string}"
 
               JOB_NAME=$(kubectl get jobs '--output=jsonpath={.items[*].metadata.name}')
 
@@ -252,6 +259,7 @@ jobs:
           TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
           TF_VAR_gcp_folder_id: ((gcp_folder_id))
           TF_VAR_gcp_billing_account: ((gcp_billing_account))
+          TF_VAR_project_env: ((gcp_project_label))
           PROJECT_NAME: ((project_name))
           SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
           GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -62,7 +62,7 @@ resources:
   - name: scheduled-benchmark-trigger
     type: time
     source:
-      start: 03:34 PM
+      start: 03:00 AM
       stop: 04:00 AM
       location: Europe/London
 

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -1,0 +1,309 @@
+resource_types:
+  - name: slack-notification
+    type: docker-image
+    source:
+      repository: cfcommunity/slack-notification-resource
+      tag: latest
+
+resources:
+
+##############################################################################
+# Git Repositories
+##############################################################################
+
+  - name: eq-survey-runner-benchmark
+    type: git
+    source:
+      uri: https://github.com/ONSdigital/eq-survey-runner-benchmark.git
+      branch: store_results_in_storge_bucket
+
+  - name: eq-terraform-load-generator
+    type: git
+    source:
+      uri: https://github.com/ONSdigital/eq-terraform-load-generator.git
+      branch: add-bucket-to-store-output
+
+##############################################################################
+# Docker Images
+##############################################################################
+
+  - name: eq-survey-runner-benchmark-image
+    type: docker-image
+    source:
+      repository: ((docker_registry))/eq-survey-runner-benchmark
+      username: _json_key
+      password: ((gcp.service_account_json))
+
+##############################################################################
+# Misc Resources
+##############################################################################
+
+  - name: slack-alert
+    type: slack-notification
+    source:
+      url: ((slack.webhook))
+
+  - name: scheduled-benchmark-trigger
+    type: time
+    source:
+      start: 03:00 AM
+      stop: 04:00 AM
+      location: Europe/London
+
+jobs:
+
+##############################################################################
+# eQ Survey Benchmark
+##############################################################################
+
+  - name: build-eq-survey-runner-benchmark
+    plan:
+    - get: eq-survey-runner-benchmark
+    - get: scheduled-benchmark-trigger
+      trigger: true
+    - put: eq-survey-runner-benchmark-image
+      params:
+        build: eq-survey-runner-benchmark
+        tag_file: eq-survey-runner-benchmark/.git/HEAD
+        tag_as_latest: true
+      get_params:
+        skip_download: true
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#((slack_channel_name))'
+        attachments:
+          - pretext: Benchmark Image Build Failed
+            color: danger
+            title: Concourse Build $BUILD_ID
+            title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
+
+##############################################################################
+# Deploy Cluster
+##############################################################################
+
+  - name: deploy-load-generator
+    serial_groups: [deploy-survey-runner-benchmark]
+    plan:
+    - get: eq-terraform-load-generator
+    - get: scheduled-benchmark-trigger
+      trigger: true
+    - task: Build & Deploy Load Generator
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: google/cloud-sdk
+        params:
+          TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
+          TF_VAR_gcp_folder_id: ((gcp_folder_id))
+          TF_VAR_gcp_billing_account: ((gcp_billing_account))
+          IMPORT_EXISTING_PROJECT: ((import_existing_project))
+          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+          GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
+        inputs:
+          - name: eq-terraform-load-generator
+        run:
+          path: bash
+          args:
+            - -exc
+            - |
+              apt-get install -y unzip
+
+              git clone https://github.com/kamatama41/tfenv.git ~/.tfenv && \
+              ln -s /root/.tfenv/bin/* /usr/local/bin
+
+              cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+              $SERVICE_ACCOUNT_JSON
+              EOL
+
+              gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+
+              cd eq-terraform-load-generator
+
+              tfenv install
+
+              ./scripts/deploy_infrastructure.sh ((project_name))
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#((slack_channel_name))'
+        attachments:
+          - pretext: Load Generator Deploy Failed
+            color: danger
+            title: Concourse Build $BUILD_ID
+            title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
+    on_success:
+      put: slack-alert
+      params:
+        channel: '#((slack_channel_name))'
+        attachments:
+          - pretext: Load Generator Deploy Passed
+            color: good
+            title: Concourse Build $BUILD_ID
+            title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
+
+##############################################################################
+# Deploy Benchmark
+##############################################################################
+
+  - name: deploy-survey-runner-benchmark
+    serial_groups: [deploy-survey-runner-benchmark]
+    plan:
+    - get: eq-survey-runner-benchmark
+    - get: scheduled-benchmark-trigger
+      passed: [build-eq-survey-runner-benchmark, deploy-load-generator]
+      trigger: true
+    - task: Deploy Survey Benchmark
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: theorf/google-cloud-sdk-helm
+        params:
+          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+        inputs:
+          - name: eq-survey-runner-benchmark
+        run:
+          path: bash
+          args:
+            - -exc
+            - |
+              apt-get install -y procps
+
+              cat >~/gcloud-service-key.json <<EOL
+              $SERVICE_ACCOUNT_JSON
+              EOL
+
+              gcloud auth activate-service-account --key-file ~/gcloud-service-key.json
+
+              cd eq-survey-runner-benchmark
+
+              helm init --client-only
+              helm plugin install https://github.com/rimusz/helm-tiller
+
+              PROJECT_ID=($(gcloud projects list --filter=name="((project_name))" --format="value(PROJECT_ID)"))
+
+              [[ "${#PROJECT_ID[@]}" = 1 ]] || exit 1
+
+              GCS_OUTPUT_BUCKET=${PROJECT_ID}-benchmark-outputs
+              COMMIT_HASH=$(cat .git/HEAD | xargs echo -n)
+
+              gcloud container clusters get-credentials runner-benchmark --region ((region)) --project ${PROJECT_ID}
+
+              helm tiller run \
+                helm upgrade --install \
+                runner-benchmark \
+                k8s/helm \
+                --set requestsJson="((requests_json))" \
+                --set locustOptions="((locust_options))" \
+                --set host=https://((runner_fully_qualified_domain_name)) \
+                --set container.image=((docker_registry))/eq-survey-runner-benchmark:${COMMIT_HASH} \
+                --set gcsOutputBucket=${GCS_OUTPUT_BUCKET} \
+                --set outputDirectory="timed-schedule"
+
+              JOB_NAME=$(kubectl get jobs '--output=jsonpath={.items[*].metadata.name}')
+
+              kubectl wait --for=condition=complete --timeout=60m job/${JOB_NAME}
+      on_failure:
+        put: slack-alert
+        params:
+          channel: '#((slack_channel_name))'
+          attachments:
+            - pretext: Survey Benchmark Deploy Failed
+              color: danger
+              title: Concourse Build $BUILD_ID
+              title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
+      on_success:
+        put: slack-alert
+        params:
+          channel: '#((slack_channel_name))'
+          attachments:
+            - pretext: Survey Benchmark Deploy Passed
+              color: good
+              title: Concourse Build $BUILD_ID
+              title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
+
+
+##############################################################################
+# Destroy Cluster
+##############################################################################
+
+  - name: destroy-load-generator
+    serial_groups: [deploy-survey-runner-benchmark]
+    plan:
+    - get: eq-terraform-load-generator
+    - get: eq-survey-runner-benchmark
+      passed: [build-eq-survey-runner-benchmark, deploy-survey-runner-benchmark]
+    - get: scheduled-benchmark-trigger
+      passed: [build-eq-survey-runner-benchmark, deploy-survey-runner-benchmark]
+      trigger: true
+    - task: Destroy Load Generator
+      config:
+        platform: linux
+        image_resource:
+          type: docker-image
+          source:
+            repository: google/cloud-sdk
+        params:
+          TF_VAR_k8s_min_master_version: ((k8s_min_master_version))
+          TF_VAR_gcp_folder_id: ((gcp_folder_id))
+          TF_VAR_gcp_billing_account: ((gcp_billing_account))
+          SERVICE_ACCOUNT_JSON: ((gcp.service_account_json))
+          GOOGLE_APPLICATION_CREDENTIALS: /root/gcloud-service-key.json
+        inputs:
+          - name: eq-terraform-load-generator
+        run:
+          path: bash
+          args:
+            - -exc
+            - |
+              apt-get install -y unzip
+
+              git clone https://github.com/kamatama41/tfenv.git ~/.tfenv && \
+              ln -s /root/.tfenv/bin/* /usr/local/bin
+
+              cat >$GOOGLE_APPLICATION_CREDENTIALS <<EOL
+              $SERVICE_ACCOUNT_JSON
+              EOL
+
+              gcloud auth activate-service-account --key-file $GOOGLE_APPLICATION_CREDENTIALS
+
+              cd eq-terraform-load-generator
+
+              tfenv install
+
+              terraform init --upgrade --backend-config prefix=((project_name)) -var "project_name=((project_name))" --backend-config bucket=((load_generator_tf_state_bucket))
+
+              # Do not delete the project or bucket.
+              terraform state rm google_project.project
+              terraform state rm google_storage_bucket.benchmark-output-storage
+
+              # Destroy infrastructure
+              terraform destroy --auto-approve -var "project_name=((project_name))"
+
+              PROJECT_ID=($(gcloud projects list --filter=name="((project_name))" --format="value(PROJECT_ID)"))
+
+              # Import project and bucket resouce back into the state
+              terraform import google_project.project "$PROJECT_ID"
+              terraform import google_storage_bucket.benchmark-output-storage ${PROJECT_ID}-benchmark-outputs
+    on_failure:
+      put: slack-alert
+      params:
+        channel: '#((slack_channel_name))'
+        attachments:
+          - pretext: Load Generator Destroy Failed
+            color: danger
+            title: Concourse Build $BUILD_ID
+            title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
+    on_success:
+      put: slack-alert
+      params:
+        channel: '#((slack_channel_name))'
+        attachments:
+          - pretext: Load Generator Destroy Passed
+            color: good
+            title: Concourse Build $BUILD_ID
+            title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -192,9 +192,9 @@ jobs:
 
               GCS_OUTPUT_BUCKET=${PROJECT_ID}-benchmark-outputs
               COMMIT_HASH=$(cat .git/HEAD | xargs echo -n)
+              RUNTIME_DATE_STRING="$(date +'%Y-%m-%dT%H:%M:%S')"
 
               gcloud container clusters get-credentials runner-benchmark --region ((region)) --project ${PROJECT_ID}
-              runtime_date_string="$(date +'%Y-%m-%dT%H:%M:%S')"
 
               helm tiller run \
                 helm upgrade --install \
@@ -210,7 +210,7 @@ jobs:
                 --set memory=((requested_memory_per_pod)) \
                 --set parallelism=((parallelism)) \
                 --set output.bucket=${GCS_OUTPUT_BUCKET} \
-                --set output.directory="timed-schedule/${runtime_date_string}"
+                --set output.directory="timed-schedule/${RUNTIME_DATE_STRING}"
 
               JOB_NAME=$(kubectl get jobs '--output=jsonpath={.items[*].metadata.name}')
 

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -53,7 +53,7 @@ resources:
 jobs:
 
 ##############################################################################
-# eQ Survey Benchmark
+# Build Survey Runner Benchmark
 ##############################################################################
 
   - name: build-survey-runner-benchmark
@@ -79,7 +79,7 @@ jobs:
             title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
 
 ##############################################################################
-# Deploy Cluster
+# Deploy Infrastructure
 ##############################################################################
 
   - name: deploy-infrastructure
@@ -146,7 +146,7 @@ jobs:
             title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
 
 ##############################################################################
-# Deploy Benchmark
+# Deploy Survey Runner Benchmark
 ##############################################################################
 
   - name: deploy-survey-runner-benchmark
@@ -229,7 +229,7 @@ jobs:
 
 
 ##############################################################################
-# Destroy Cluster
+# Destroy Infrastructure
 ##############################################################################
 
   - name: destroy-infrastructure

--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -31,13 +31,13 @@ resources:
     type: git
     source:
       uri: https://github.com/ONSdigital/eq-survey-runner-benchmark.git
-      branch: store_results_in_storge_bucket
+      branch: master
 
   - name: eq-terraform-load-generator
     type: git
     source:
       uri: https://github.com/ONSdigital/eq-terraform-load-generator.git
-      branch: add-bucket-to-store-output
+      branch: master
 
 ##############################################################################
 # Docker Images

--- a/variables.yaml.example
+++ b/variables.yaml.example
@@ -1,0 +1,35 @@
+# Currently the docker registry can only be a GCR registry
+# which is accessible using the concourse service account.
+# The gcp_project_id should be the project id where the container registry is hosted.
+docker_registry: eu.gcr.io/<gcp_project_id}>
+
+import_existing_project: false
+# The environment you would like to provision e.g. dev
+# This should be the full project id if it is an existing project.
+project_name: ''
+
+# If a non development state bucket for the terraform backend is used, specify it here
+load_generator_tf_state_bucket: 'eq-terraform-load-generator-tfstate'
+
+# Override the default kubernetes version if necessary
+k8s_min_master_version: 1.13
+gcp_folder_id: ''
+gcp_billing_account: ''
+region: 'europe-west2'
+
+slack_channel_name: ''
+
+# The label for this project in GCP
+gcp_project_label: 'eq'
+
+# The full DNS name for runner
+# For example: myenv-runner.gcp.dev.eq.ons.digital
+runner_fully_qualified_domain_name: ''
+
+requested_cpu_per_pod: 0.7
+requested_memory_per_pod: '2048Mi'
+parallelism: 1
+user_wait_time_min_seconds: 1
+user_wait_time_max_seconds: 2
+requests_json: 'requests/census_individual_gb_eng.json'
+locust_options: '--no-web -c 1 -r 1 -t 10m --csv=output -L WARNING'

--- a/variables.yaml.example
+++ b/variables.yaml.example
@@ -26,10 +26,10 @@ gcp_project_label: 'sandbox-eq'
 # For example: myenv-runner.gcp.dev.eq.ons.digital
 runner_fully_qualified_domain_name: ''
 
-requested_cpu_per_pod: 0.7
+requested_cpu_per_pod: '0.7'
 requested_memory_per_pod: '2048Mi'
 parallelism: 1
-user_wait_time_min_seconds: 1
-user_wait_time_max_seconds: 2
+user_wait_time_min_seconds: 0
+user_wait_time_max_seconds: 0
 requests_json: 'requests/census_individual_gb_eng.json'
 locust_options: '--no-web -c 1 -r 1 -t 10m --csv=output -L WARNING'

--- a/variables.yaml.example
+++ b/variables.yaml.example
@@ -1,5 +1,5 @@
-# Currently the docker registry can only be a GCR registry
-# which is accessible using the concourse service account.
+# Currently the docker registry can only be a GCR registry.
+# Ensure in the GCR settings, the visibility is set to Public.
 # The gcp_project_id should be the project id where the container registry is hosted.
 docker_registry: eu.gcr.io/<gcp_project_id}>
 

--- a/variables.yaml.example
+++ b/variables.yaml.example
@@ -20,7 +20,7 @@ region: 'europe-west2'
 slack_channel_name: ''
 
 # The label for this project in GCP
-gcp_project_label: 'eq'
+gcp_project_label: 'sandbox-eq'
 
 # The full DNS name for runner
 # For example: myenv-runner.gcp.dev.eq.ons.digital


### PR DESCRIPTION
Added a pipeline to automate the performance testing of runner.

### How to review 
- Can you fly the pipeline using the README?
- Ensure that a benchmark is run using options specified by `locust_options`.
- Ensure the benchmark results are stored inside the bucket and is persisted.
- Ensure infrastructure is deleted on the destroy task.

Note: The google project and GCS bucket are not destroyed. Only the main infrastructure is destroyed after a successful run.

Firstly review: https://github.com/ONSdigital/eq-terraform-load-generator/pull/2