### PR TITLE
Fix the slack alert message for destroy task

### DIFF
--- a/benchmark-timed-schedule.yaml
+++ b/benchmark-timed-schedule.yaml
@@ -306,7 +306,7 @@ jobs:
       params:
         channel: '#((slack_channel_name))'
         attachments:
-          - pretext: Load Generator Infrastructure Deploy Failed
+          - pretext: Load Generator Infrastructure Destroy Failed
             color: danger
             title: Concourse Build $BUILD_ID
             title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID
@@ -315,7 +315,7 @@ jobs:
       params:
         channel: '#((slack_channel_name))'
         attachments:
-          - pretext: Load Generator Infrastructure Deploy Passed
+          - pretext: Load Generator Infrastructure Destroy Passed
             color: good
             title: Concourse Build $BUILD_ID
             title_link: $ATC_EXTERNAL_URL/builds/$BUILD_ID


### PR DESCRIPTION
Simple PR to fix the slack alert text to notify when the destroy has failed/passed.