### PR TITLE
Remove unused terraform key

### DIFF
--- a/daily-test/variables.yaml
+++ b/daily-test/variables.yaml
@@ -9,9 +9,6 @@ docker:
   app_registry: 'eu.gcr.io/census-eq-ci'
   build_image_registry: 'eu.gcr.io/census-eq-ci'
 
-terraform:
-  state_bucket: 'eq-terraform-load-generator-tfstate'
-
 slack_channel:
   name: 'eq-daily-performance-test'
 

--- a/stress-test/variables.yaml
+++ b/stress-test/variables.yaml
@@ -9,9 +9,6 @@ docker:
   app_registry: 'eu.gcr.io/census-eq-ci'
   build_image_registry: 'eu.gcr.io/census-eq-ci'
 
-terraform:
-  state_bucket: 'eq-terraform-load-generator-tfstate'
-
 slack_channel:
   name: 'eq-stress-test'
 


### PR DESCRIPTION
### What is the context of this PR?
The state bucket isn't being used, as it defaults to `eq-terraform-load-generator-tfstate` in the ci tasks.

### How to review
Fly these pipelines using your own variables files that point to a new gcp project. make sure the pipeline runs correctly, and that after the stress test new folders are added to the eq-terraform-load-generator-tfstate bucket in GCP with your environment name as the folder name
