### PR TITLE
Increase locust clients per instance and use household journey

### DIFF
--- a/daily-test/variables.yaml
+++ b/daily-test/variables.yaml
@@ -18,8 +18,8 @@ slack_channel:
 benchmark:
   image_tag: 'latest'
   instances: 1
-  clients_per_instance: '40'
-  clients_hatch_rate: '40'
+  clients_per_instance: '20'
+  clients_hatch_rate: '20'
   user_wait_time_min_seconds: 0
   user_wait_time_max_seconds: 0
   requests_json: 'requests/census_household_gb_eng.json'

--- a/daily-test/variables.yaml
+++ b/daily-test/variables.yaml
@@ -22,7 +22,7 @@ benchmark:
   clients_hatch_rate: '40'
   user_wait_time_min_seconds: 0
   user_wait_time_max_seconds: 0
-  requests_json: 'requests/census_individual_gb_eng.json'
+  requests_json: 'requests/census_household_gb_eng.json'
   run_time: '30m'
   timeout: '60m'
   target_fully_qualified_domain_name: 'test-runner.gcp.dev.eq.ons.digital'

--- a/daily-test/variables.yaml
+++ b/daily-test/variables.yaml
@@ -18,8 +18,8 @@ slack_channel:
 benchmark:
   image_tag: 'latest'
   instances: 1
-  clients_per_instance: '10'
-  clients_hatch_rate: '10'
+  clients_per_instance: '40'
+  clients_hatch_rate: '40'
   user_wait_time_min_seconds: 0
   user_wait_time_max_seconds: 0
   requests_json: 'requests/census_individual_gb_eng.json'


### PR DESCRIPTION
The daily performance tests were seeing deviations in response times that were potentially caused by too low a load during the test run. This PR doubles the number of locust clients to 20 in an attempt to generate a greater and more consistent load. This also changes the requests file from the individual to household to test the a more common journey exercising more functionality.

These changes have already been flown, tested, and are in use in the eq-daily-performance-test pipeline.