### PR TITLE
Add error alerts

### DIFF
--- a/daily-test/pipeline.yaml
+++ b/daily-test/pipeline.yaml
@@ -86,6 +86,11 @@ jobs:
       params:
         message: Load Generator Infrastructure Deploy Failed
         alert_type: failed
+    on_error:
+      put: slack-alert
+      params:
+        message: Load Generator Infrastructure Deploy Errored
+        alert_type: failed
     on_success:
       put: slack-alert
       params:
@@ -112,6 +117,11 @@ jobs:
       put: slack-alert
       params:
         message: Survey Runner Benchmark Failed
+        alert_type: failed
+    on_error:
+      put: slack-alert
+      params:
+        message: Survey Runner Benchmark Errored
         alert_type: failed
     on_success:
       put: slack-alert
@@ -141,6 +151,11 @@ jobs:
       put: slack-alert
       params:
         message: Load Generator Infrastructure Destroy Failed
+        alert_type: failed
+    on_error:
+      put: slack-alert
+      params:
+        message: Load Generator Infrastructure Destroy Errored
         alert_type: failed
     on_success:
       put: slack-alert

--- a/daily-test/pipeline.yaml
+++ b/daily-test/pipeline.yaml
@@ -91,6 +91,7 @@ jobs:
       params:
         message: Load Generator Infrastructure Deploy Errored
         alert_type: failed
+        color: '#F4A624'
     on_success:
       put: slack-alert
       params:
@@ -123,6 +124,8 @@ jobs:
       params:
         message: Survey Runner Benchmark Errored
         alert_type: failed
+        color: '#F4A624'
+
     on_success:
       put: slack-alert
       params:
@@ -157,6 +160,7 @@ jobs:
       params:
         message: Load Generator Infrastructure Destroy Errored
         alert_type: failed
+        color: '#F4A624'
     on_success:
       put: slack-alert
       params:

--- a/stress-test/pipeline.yaml
+++ b/stress-test/pipeline.yaml
@@ -82,6 +82,7 @@ jobs:
       params:
         message: Load Generator Infrastructure Deploy Errored
         alert_type: failed
+        color: '#F4A624'
     on_success:
       put: slack-alert
       params:
@@ -113,6 +114,7 @@ jobs:
         params:
           message: Survey Runner Stress Test Errored
           alert_type: failed
+          color: '#F4A624'
       on_success:
         put: slack-alert
         params:
@@ -145,6 +147,7 @@ jobs:
       params:
         message: Load Generator Infrastructure Destroy Errored
         alert_type: failed
+        color: '#F4A624'
     on_success:
       put: slack-alert
       params:

--- a/stress-test/pipeline.yaml
+++ b/stress-test/pipeline.yaml
@@ -77,6 +77,11 @@ jobs:
       params:
         message: Load Generator Infrastructure Deploy Failed
         alert_type: failed
+    on_error:
+      put: slack-alert
+      params:
+        message: Load Generator Infrastructure Deploy Errored
+        alert_type: failed
     on_success:
       put: slack-alert
       params:
@@ -102,6 +107,11 @@ jobs:
         put: slack-alert
         params:
           message: Survey Runner Stress Test Failed
+          alert_type: failed
+      on_error:
+        put: slack-alert
+        params:
+          message: Survey Runner Stress Test Errored
           alert_type: failed
       on_success:
         put: slack-alert
@@ -129,6 +139,11 @@ jobs:
       put: slack-alert
       params:
         message: Load Generator Infrastructure Destroy Failed
+        alert_type: failed
+    on_error:
+      put: slack-alert
+      params:
+        message: Load Generator Infrastructure Destroy Errored
         alert_type: failed
     on_success:
       put: slack-alert


### PR DESCRIPTION
### What is the context of this PR?
Adds Slack alerts for pipeline errors.

### How to review
Fly each of the pipelines using your own slack alerting channel. Configure one of the vars used in the pipeline incorrectly so that an error is triggered. Ensure that the correct alert is published in the Slack channel. 