### PR TITLE
Updating variables to use dockerhub images instead of GCR

### DIFF
--- a/daily-test/variables.yaml
+++ b/daily-test/variables.yaml
@@ -6,7 +6,7 @@ k8s:
   node_machine_type: 'custom-1-2560'
 
 docker:
-  app_registry: 'eu.gcr.io/census-eq-ci'
+  app_registry: 'docker.io/onsdigital'
   build_image_registry: 'eu.gcr.io/census-eq-ci'
 
 slack_channel:

--- a/stress-test/variables.yaml
+++ b/stress-test/variables.yaml
@@ -6,7 +6,7 @@ k8s:
   node_machine_type: 'custom-1-2560'
 
 docker:
-  app_registry: 'eu.gcr.io/census-eq-ci'
+  app_registry: 'docker.io/onsdigital'
   build_image_registry: 'eu.gcr.io/census-eq-ci'
 
 slack_channel:

--- a/variables.yaml.example
+++ b/variables.yaml.example
@@ -8,11 +8,9 @@ project:
 k8s:
   node_machine_type: 'custom-1-2560'
 
-# Currently the docker registry can only be a GCR registry.
-# Ensure in the GCR settings, the visibility is set to Public.
 # The project.id should be the project id where the container registry is hosted.
 docker:
-  app_registry: 'eu.gcr.io/<google.project_id>'
+  app_registry: 'docker.io/onsdigital'
   build_image_registry: 'eu.gcr.io/census-eq-ci'
 
 # If a non development state bucket for the terraform backend is used, specify it here


### PR DESCRIPTION
The pipelines should be able to pull and deploy the latest dockerhub image rather than the historical latest GCR image which is currently no longer pushed/updated. 
